### PR TITLE
Bug: feat menu reference

### DIFF
--- a/themes/twhugo/layouts/_default/single.html
+++ b/themes/twhugo/layouts/_default/single.html
@@ -99,7 +99,7 @@
     <div id="menu-reference" 
          class="fixed top-[100px] 
                 transition-all ease-in-out duration-200
-                -right-[400px]">
+                -right-[400px] lg:hidden">
         <div class="w-full 
                     h-screen bg-slate-800 
                     px-8 py-5">


### PR DESCRIPTION
Saya rasa ini adalah bug kak @hilmanski , 

![Bug Koding](https://user-images.githubusercontent.com/108800230/219876795-059b80e2-8cdc-43e4-8f21-14788eb7ffc2.PNG)

Ketika menunya dibuka di device kecil kemudian devicenya diperbesar maka menunya tetap terbuka. Apakah ini disengaja kak @hilmanski , karena bug-nya pun tidak mungkin muncul dalam penggunaan user saya rasa. Ini hanya saran saja, kalau memang disengaja bisa di close saja PR